### PR TITLE
Allow a specific version to be installed

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,7 @@ The tasks look for `choco.exe` at the `chocolatey_path`. The installer Powershel
 
     chocolatey_installer: https://chocolatey.org/install.ps1
     chocolatey_path: c:/ProgramData/chocolatey
+    chocolatey_version: latest
     chocolatey_windows_compression: "false"
 
 Example Playbook

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -2,4 +2,5 @@
 
 chocolatey_installer: https://chocolatey.org/install.ps1
 chocolatey_path: c:/ProgramData/chocolatey
+chocolatey_version: latest
 chocolatey_windows_compression: "false"

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -9,13 +9,24 @@
     var: chocolatey_exe
     verbosity: 2
 
-- name: "Install Chocolatey."
+- name: "Install latest Chocolatey."
   raw: "$env:chocolateyUseWindowsCompression='{{ chocolatey_windows_compression }}'; \
   iex ((New-Object System.Net.WebClient).DownloadString('{{ chocolatey_installer }}'))"
   register: chocolatey_install_result
   when:
     - chocolatey_exe.stat.exists is defined
     - not chocolatey_exe.stat.exists
+    - chocolatey_version == "latest"
+
+- name: "Install specific Chocolatey."
+  raw: "$env:chocolateyUseWindowsCompression='{{ chocolatey_windows_compression }}'; \
+  $env:chocolateyVersion = '{{ chocolatey_version }}'; \
+  iex ((New-Object System.Net.WebClient).DownloadString('{{ chocolatey_installer }}'))"
+  register: chocolatey_install_result
+  when:
+    - chocolatey_exe.stat.exists is defined
+    - not chocolatey_exe.stat.exists
+    - chocolatey_version != "latest"
 
 - debug:
     var: chocolatey_install_result


### PR DESCRIPTION
This enables pinning via https://chocolatey.org/install#installing-a-particular-version-of-chocolatey.

There was a recent change in choco behaviour that is addressed in https://github.com/ansible/ansible/pull/53841 that current ansible 2.7.5 I'm using doesn't have. Fix was backported, I think, but this seems like a sound idea anyhow.