### PR TITLE
Use explicit TLS 1.2 to download chocolatey

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -11,6 +11,7 @@
 
 - name: "Install latest Chocolatey."
   raw: "$env:chocolateyUseWindowsCompression='{{ chocolatey_windows_compression }}'; \
+  [Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12; \
   iex ((New-Object System.Net.WebClient).DownloadString('{{ chocolatey_installer }}'))"
   register: chocolatey_install_result
   when:


### PR DESCRIPTION
As of 3rd Feb, chocolatey have deprecated TLS 1 and 1.1
https://chocolatey.org/blog/remove-support-for-old-tls-versions

Without explicitly specifying 1.2, this causes the role to fail on machines where 1 is the default in powershell